### PR TITLE
Windows fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "twit": "^2.2.5"
   },
   "scripts": {
-    "start": "concurrently  'tsc --p ./tsconfig-client.json -w' 'tsc --p ./tsconfig-server.json -w' 'nodemon --watch ./src/server --ignore node_modules/ --exec node src/server'"
+    "one" : "tsc --p ./tsconfig-client.json -w",
+    "two" : "tsc --p ./tsconfig-server.json -w",
+    "three" : "nodemon --watch ./src/server --ignore node_modules/ --exec node src/server",
+    "start": "concurrently  \"npm run one\" \"npm run two\" \"npm run three\""
   }
 }


### PR DESCRIPTION
Splitted into multiple commands. Escape quotes are very bad on windows command buffer. 